### PR TITLE
Fix types to export default

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,2 +1,3 @@
 import { Source } from 'callbag';
-export declare const interval: (period: number) => Source<number>;
+declare const interval: (period: number) => Source<number>;
+export default interval


### PR DESCRIPTION
The actual module exports default, not a named export.