### PR TITLE
Fix typescript error TS2349.

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,3 @@
 import { Source } from 'callbag';
 declare const interval: (period: number) => Source<number>;
-export default interval
+export = interval;


### PR DESCRIPTION
When using typescript import:

import * as interval from 'callbag-interval';

It fix the error TS2349.